### PR TITLE
Show responsive grid by default instead of simple

### DIFF
--- a/projects/aem-angular-core-spa-wcm-components/containers/container/v1/src/container.v1.component.ts
+++ b/projects/aem-angular-core-spa-wcm-components/containers/container/v1/src/container.v1.component.ts
@@ -51,7 +51,7 @@ export class ContainerV1Component extends AEMResponsiveGridComponent implements 
 
 
     showResponsiveGrid():boolean{
-        return this.layout === ContainerLayout.RESPONSIVEGRID;
+        return this.layout !== ContainerLayout.SIMPLE;
     }
 
     @HostBinding('style')


### PR DESCRIPTION
Put the default editing mode of container v1 to responsivegrid until the type property is outputted by the core comopnents